### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-tests.yml
+++ b/.github/workflows/docker-tests.yml
@@ -7,6 +7,9 @@ on:
     branches: [ master ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   docker_tests:
     if: github.event.pull_request.draft == false


### PR DESCRIPTION
Potential fix for [https://github.com/TiCodeX/SQLSchemaCompare/security/code-scanning/2](https://github.com/TiCodeX/SQLSchemaCompare/security/code-scanning/2)

Add an explicit `permissions` block at the workflow root in `.github/workflows/docker-tests.yml`, just after the trigger section (`on:` block) and before `jobs:`.  
For this workflow, the minimal and safest setting is:

- `contents: read`

This preserves existing behavior (`actions/checkout` needs repository read access) while ensuring the token is not accidentally granted broader rights by repository/org defaults. No other logic or steps need to change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
