### PR TITLE
Potential fix for code scanning alert no. 8: DOM text reinterpreted as HTML

### DIFF
--- a/SQLSchemaCompare.UI/wwwroot/js/Main.ts
+++ b/SQLSchemaCompare.UI/wwwroot/js/Main.ts
@@ -86,9 +86,9 @@ class Main {
     }
     const diffItemName = $(".tcx-diff-item-name");
     diffItemName.empty();
-    diffItemName.append(document.createTextNode(`${sourceItem} `));
-    diffItemName.append($("<span>").addClass("fa fa-long-arrow-alt-right"));
-    diffItemName.append(document.createTextNode(` ${targetItem}`));
+    diffItemName.append(document.createTextNode(sourceItem));
+    diffItemName.append($("<span>").addClass("fa fa-long-arrow-alt-right mx-1"));
+    diffItemName.append(document.createTextNode(targetItem));
 
     void Utility.AjaxCall<CompareResultItemScripts>(this.resultItemScriptsUrl + rowId, HttpMethod.Get).then((response): void => {
       EditorManager.CreateEditor(EditorType.Diff, "sqlDiff", {

--- a/SQLSchemaCompare.UI/wwwroot/js/Main.ts
+++ b/SQLSchemaCompare.UI/wwwroot/js/Main.ts
@@ -84,7 +84,11 @@ class Main {
     if (Utility.IsNullOrWhitespace(targetItem)) {
       targetItem = Localization.Get("LabelDoesNotExist");
     }
-    $(".tcx-diff-item-name").html(`${sourceItem} <span class='fa fa-long-arrow-alt-right'></span> ${targetItem}`);
+    const diffItemName = $(".tcx-diff-item-name");
+    diffItemName.empty();
+    diffItemName.append(document.createTextNode(`${sourceItem} `));
+    diffItemName.append($("<span>").addClass("fa fa-long-arrow-alt-right"));
+    diffItemName.append(document.createTextNode(` ${targetItem}`));
 
     void Utility.AjaxCall<CompareResultItemScripts>(this.resultItemScriptsUrl + rowId, HttpMethod.Get).then((response): void => {
       EditorManager.CreateEditor(EditorType.Diff, "sqlDiff", {


### PR DESCRIPTION
Potential fix for [https://github.com/TiCodeX/SQLSchemaCompare/security/code-scanning/8](https://github.com/TiCodeX/SQLSchemaCompare/security/code-scanning/8)

Use safe DOM construction that inserts untrusted values as text nodes, not HTML.  
Best fix here: replace the `.html(...)` call with:
1. `empty()` the target container,
2. append `sourceItem` as text,
3. append the icon span as a created element with classes,
4. append `targetItem` as text.

This preserves existing UI behavior (text + arrow icon + text) while preventing HTML parsing of `sourceItem`/`targetItem`.

Edit only `SQLSchemaCompare.UI/wwwroot/js/Main.ts` in the `ShowBottomPanel` method around line 87. No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
