### PR TITLE
Support PostgreSQL array backfill values

### DIFF
--- a/SQLSchemaCompare.Infrastructure/SqlScripters/PostgreSqlScriptHelper.cs
+++ b/SQLSchemaCompare.Infrastructure/SqlScripters/PostgreSqlScriptHelper.cs
@@ -200,6 +200,9 @@ public class PostgreSqlScriptHelper(ProjectOptions options) : AScriptHelper(opti
             // User defined types
             "USER-DEFINED" => column.ColumnDefault,
 
+            // Arrays
+            "ARRAY" => "'{}'",
+
             // Other data types
             "json" or "jsonb" => "'{}'",
             "name" or "tsquery" or "tsvector" => "''",


### PR DESCRIPTION
Adds support for PostgreSQL array columns when generating update scripts for new NOT NULL columns. Existing rows are backfilled with an empty array before the NOT NULL constraint is applied.